### PR TITLE
Support custom entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,32 @@ while libBIDS_csv_iterator "$func_csv" row "sub" "ses" "run"; do
 done
 ```
 
+## Customization
+
+### Adding non-BIDS entities 
+
+If your dataset uses an entity that is not part of the official BIDS specification, you can include them in the parsing logic via JSON file(s) in the `custom` directory:
+
+```json
+{
+  "entities": [
+    {
+      "name": "foo",
+      "display_name": "fooval",
+      "pattern": "*(_foo-+([a-zA-Z0-9]))"
+    },
+    {
+      "name": "bar",
+      "display_name": "baridx",
+      "pattern": "*(_bar-+([0-9]))"
+    }
+    ...
+  ]
+}
+```
+
+To see an example, rename the template file from `custom/custom_entities.json.tpl` to `custom/custom_entities.json`.
+
 ## Notes
 
 - All functions handle CSV data as strings, not files

--- a/custom/custom_entities.json.tpl
+++ b/custom/custom_entities.json.tpl
@@ -1,0 +1,9 @@
+{
+  "entities": [
+    {
+      "name": "bp",
+      "display_name": "bodypart",
+      "pattern": "*(_bp-+([a-zA-Z0-9]))"
+    }
+  ]
+}

--- a/libBIDS.sh
+++ b/libBIDS.sh
@@ -379,7 +379,20 @@ _libBIDSsh_load_custom_entities() {
   fi
   
   shopt -s nullglob
-  for json_file in "$plugin_dir"/*.json; do
+  local json_files=("$plugin_dir"/*.json)
+  shopt -u nullglob
+
+  if ((${#json_files[@]} == 0)); then
+    return 0
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "Error: jq is required for custom entity support" >&2
+    return 1
+  fi
+
+  shopt -s nullglob
+  for json_file in "${json_files[@]}"; do
     if [[ -f "$json_file" ]]; then
       # Parse JSON and extract entity definitions
       while IFS=';' read -r name display_name pattern; do

--- a/libBIDS.sh
+++ b/libBIDS.sh
@@ -355,6 +355,10 @@ _libBIDSsh_load_custom_entities() {
   
   local script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   local plugin_dir="${script_dir}/custom"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "Error: jq is required for custom entity support" >&2
+    return 1
+  fi
   
   # Initialize global arrays if not already defined
   if [[ -z "${CUSTOM_ENTITIES+x}" ]]; then

--- a/libBIDS.sh
+++ b/libBIDS.sh
@@ -382,14 +382,14 @@ _libBIDSsh_load_custom_entities() {
   for json_file in "$plugin_dir"/*.json; do
     if [[ -f "$json_file" ]]; then
       # Parse JSON and extract entity definitions
-      while IFS='|' read -r name display_name pattern; do
+      while IFS=';' read -r name display_name pattern; do
         if [[ -n "$name" && -n "$display_name" && -n "$pattern" ]]; then
           CUSTOM_ENTITIES["$name"]="$pattern"
           CUSTOM_ENTITY_NAMES+=("$name")
           CUSTOM_ENTITY_DISPLAY_NAMES+=("$display_name")
         fi
       done < <(
-        jq -r '.entities[] | "\(.name)|\(.display_name)|\(.pattern)"' \
+        jq -r '.entities[] | "\(.name);\(.display_name);\(.pattern)"' \
           "$json_file" 2>/dev/null
       )
     fi

--- a/libBIDS.sh
+++ b/libBIDS.sh
@@ -364,12 +364,15 @@ _libBIDSsh_load_custom_entities() {
   if [[ -z "${CUSTOM_ENTITIES+x}" ]]; then
     declare -gA CUSTOM_ENTITIES
   fi
+  CUSTOM_ENTITIES=()
   if [[ -z "${CUSTOM_ENTITY_NAMES+x}" ]]; then
     declare -ga CUSTOM_ENTITY_NAMES
   fi
+  CUSTOM_ENTITY_NAMES=()
   if [[ -z "${CUSTOM_ENTITY_DISPLAY_NAMES+x}" ]]; then
     declare -ga CUSTOM_ENTITY_DISPLAY_NAMES
   fi
+  CUSTOM_ENTITY_DISPLAY_NAMES=()
   
   if [[ ! -d "$plugin_dir" ]]; then
     return 0

--- a/libBIDS.sh
+++ b/libBIDS.sh
@@ -371,24 +371,23 @@ _libBIDSsh_load_custom_entities() {
     return 0
   fi
   
-  # Load all .json files in the plugin directory
+  shopt -s nullglob
   for json_file in "$plugin_dir"/*.json; do
     if [[ -f "$json_file" ]]; then
       # Parse JSON and extract entity definitions
-      while IFS= read -r line; do
-        local name=$(echo "$line" | cut -d'|' -f1)
-        local display_name=$(echo "$line" | cut -d'|' -f2)
-        local pattern=$(echo "$line" | cut -d'|' -f3)
-        
+      while IFS='|' read -r name display_name pattern; do
         if [[ -n "$name" && -n "$display_name" && -n "$pattern" ]]; then
           CUSTOM_ENTITIES["$name"]="$pattern"
           CUSTOM_ENTITY_NAMES+=("$name")
           CUSTOM_ENTITY_DISPLAY_NAMES+=("$display_name")
         fi
-      done < <(jq -r '.entities[] | "\(.name)|\(.display_name)|\(.pattern)"' "$json_file" 2>/dev/null)
+      done < <(
+        jq -r '.entities[] | "\(.name)|\(.display_name)|\(.pattern)"' \
+          "$json_file" 2>/dev/null
+      )
     fi
   done
-  
+  shopt -u nullglob
 }
 
 libBIDSsh_parse_bids_to_csv() {

--- a/libBIDS.sh
+++ b/libBIDS.sh
@@ -351,7 +351,7 @@ _libBIDSsh_load_custom_entities() {
   #   - name: entity short name
   #   - display_name: entity display name for CSV headers
   #   - pattern: bash glob pattern for matching
-  #   - description: optional description
+
   
   local script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   local plugin_dir="${script_dir}/custom"
@@ -389,12 +389,6 @@ _libBIDSsh_load_custom_entities() {
     fi
   done
   
-  # Still support .sh files for backward compatibility
-  for plugin_file in "$plugin_dir"/*.sh; do
-    if [[ -f "$plugin_file" ]]; then
-      source "$plugin_file"
-    fi
-  done
 }
 
 libBIDSsh_parse_bids_to_csv() {


### PR DESCRIPTION
In some datasets, custom entities had to be used. For example, NeuroMod used a custom `bp` (`bodypart`) entity to distinguish spinal cord scans, this was before `voi` was introduced.

This little extension enables parser to incorporate suffixes from a json file placed under the `custom` folder. I thought it would be a good option to have. 

> [!NOTE]
> I only tested it using `libBIDSsh_parse_bids_to_csv`. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can define custom BIDS entities via JSON; those entities are recognized during file parsing and included in parsed outputs, CSV headers, and entity ordering.

* **Documentation**
  * README adds a "Customization" section with instructions and an example template for creating custom entity definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->