### PR TITLE
Add Frictionless Data Table Schema for libBIDS.sh output

### DIFF
--- a/table_schema.json
+++ b/table_schema.json
@@ -1,0 +1,407 @@
+{
+  "profile": "tabular-data-schema",
+  "missingValues": [
+    "NA",
+    ""
+  ],
+  "primaryKey": "path",
+  "fields": [
+    {
+      "name": "derivatives",
+      "title": "Derivative Pipeline",
+      "type": "string",
+      "description": "Pipeline name extracted from the derivatives/ folder path. NA if the file is not in a derivatives directory."
+    },
+    {
+      "name": "data_type",
+      "title": "Data Type",
+      "type": "string",
+      "description": "BIDS data type inferred from the directory structure, indicating the broad category of data.",
+      "constraints": {
+        "required": true,
+        "enum": [
+          "anat",
+          "beh",
+          "dwi",
+          "eeg",
+          "fmap",
+          "func",
+          "ieeg",
+          "meg",
+          "micr",
+          "motion",
+          "mrs",
+          "perf",
+          "pet",
+          "phenotype",
+          "nirs"
+        ]
+      }
+    },
+    {
+      "name": "subject",
+      "title": "Subject",
+      "type": "string",
+      "format": "label",
+      "description": "A person or animal participating in the study. Corresponds to the sub-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "session",
+      "title": "Session",
+      "type": "string",
+      "format": "label",
+      "description": "A logical grouping of neuroimaging and behavioral data consistent across subjects. Corresponds to the ses-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "sample",
+      "title": "Sample",
+      "type": "string",
+      "format": "label",
+      "description": "A sample pertaining to a subject such as tissue, primary cell, or cell-free sample. Corresponds to the sample-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "task",
+      "title": "Task",
+      "type": "string",
+      "format": "label",
+      "description": "A set of structured activities performed by the participant. Corresponds to the task-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "tracksys",
+      "title": "Tracking System",
+      "type": "string",
+      "format": "label",
+      "description": "Tracking system used for motion data. Corresponds to the tracksys-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "acquisition",
+      "title": "Acquisition",
+      "type": "string",
+      "format": "label",
+      "description": "Custom label to distinguish a different set of parameters used for acquiring the same modality. Corresponds to the acq-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "nucleus",
+      "title": "Nucleus",
+      "type": "string",
+      "format": "label",
+      "description": "Nucleus or nuclei targeted by the acquisition, corresponding to DICOM Tag 0018,9100. Corresponds to the nuc-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "volume",
+      "title": "Volume of Interest",
+      "type": "string",
+      "format": "label",
+      "description": "Region or body part scanned, used to distinguish acquisitions localized to different regions. Corresponds to the voi-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "ceagent",
+      "title": "Contrast Enhancing Agent",
+      "type": "string",
+      "format": "label",
+      "description": "Contrast agent used to distinguish sequences using different contrast enhanced images. Corresponds to the ce-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "tracer",
+      "title": "Tracer",
+      "type": "string",
+      "format": "label",
+      "description": "Tracer used to distinguish sequences using different tracers. Corresponds to the trc-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "stain",
+      "title": "Stain",
+      "type": "string",
+      "format": "label",
+      "description": "Stain or antibody used for contrast enhancement in microscopy. Corresponds to the stain-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "reconstruction",
+      "title": "Reconstruction",
+      "type": "string",
+      "format": "label",
+      "description": "Reconstruction algorithm used (for example, MoCo for motion correction). Corresponds to the rec-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "direction",
+      "title": "Phase-Encoding Direction",
+      "type": "string",
+      "format": "label",
+      "description": "Phase-encoding direction used to distinguish different acquisitions (for example, AP, PA, LR, RL). Corresponds to the dir-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "run",
+      "title": "Run",
+      "type": "string",
+      "format": "index",
+      "description": "Run index distinguishing separate data acquisitions with the same parameters and entities. Nonnegative integer. Corresponds to the run-<index> entity.",
+      "constraints": {
+        "pattern": "^[0-9]+$"
+      }
+    },
+    {
+      "name": "modality",
+      "title": "Corresponding Modality",
+      "type": "string",
+      "format": "label",
+      "description": "Modality label for defacing masks, referencing the modality of the image being defaced. Corresponds to the mod-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "echo",
+      "title": "Echo",
+      "type": "string",
+      "format": "index",
+      "description": "Echo index distinguishing files acquired at different echo times. Nonnegative integer. Corresponds to the echo-<index> entity.",
+      "constraints": {
+        "pattern": "^[0-9]+$"
+      }
+    },
+    {
+      "name": "flip",
+      "title": "Flip Angle",
+      "type": "string",
+      "format": "index",
+      "description": "Flip angle index distinguishing files acquired at different flip angles. Nonnegative integer. Corresponds to the flip-<index> entity.",
+      "constraints": {
+        "pattern": "^[0-9]+$"
+      }
+    },
+    {
+      "name": "inversion",
+      "title": "Inversion Time",
+      "type": "string",
+      "format": "index",
+      "description": "Inversion time index distinguishing files acquired at different inversion times. Nonnegative integer. Corresponds to the inv-<index> entity.",
+      "constraints": {
+        "pattern": "^[0-9]+$"
+      }
+    },
+    {
+      "name": "mtransfer",
+      "title": "Magnetization Transfer",
+      "type": "string",
+      "format": "label",
+      "description": "Magnetization transfer state indicating presence or absence of an MT pulse. Corresponds to the mt-<label> entity.",
+      "constraints": {
+        "enum": ["on", "off"]
+      }
+    },
+    {
+      "name": "part",
+      "title": "Part",
+      "type": "string",
+      "format": "label",
+      "description": "Component of the complex MRI signal representation (magnitude, phase, real, or imaginary). Corresponds to the part-<label> entity.",
+      "constraints": {
+        "enum": ["mag", "phase", "real", "imag"]
+      }
+    },
+    {
+      "name": "processing",
+      "title": "Processed (on device)",
+      "type": "string",
+      "format": "label",
+      "description": "Processing variant performed on the device, analogous to rec for MR (for example, MaxFilter sss, tsss, trans). Corresponds to the proc-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "hemisphere",
+      "title": "Hemisphere",
+      "type": "string",
+      "format": "label",
+      "description": "Hemibrain described by the file. Corresponds to the hemi-<label> entity.",
+      "constraints": {
+        "enum": ["L", "R"]
+      }
+    },
+    {
+      "name": "space",
+      "title": "Space",
+      "type": "string",
+      "format": "label",
+      "description": "Coordinate system or reference image for interpreting spatial coordinates. Corresponds to the space-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "split",
+      "title": "Split",
+      "type": "string",
+      "format": "index",
+      "description": "Split index for long recordings that exceed file size limits (for example, 2GB .fif files). Nonnegative integer. Corresponds to the split-<index> entity.",
+      "constraints": {
+        "pattern": "^[0-9]+$"
+      }
+    },
+    {
+      "name": "recording",
+      "title": "Recording",
+      "type": "string",
+      "format": "label",
+      "description": "Label distinguishing continuous recording files from different instruments, sampling frequencies, or start times. Corresponds to the recording-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "chunk",
+      "title": "Chunk",
+      "type": "string",
+      "format": "index",
+      "description": "Chunk index distinguishing images of the same physical sample with different fields of view. Nonnegative integer. Corresponds to the chunk-<index> entity.",
+      "constraints": {
+        "pattern": "^[0-9]+$"
+      }
+    },
+    {
+      "name": "segmentation",
+      "title": "Segmentation",
+      "type": "string",
+      "format": "label",
+      "description": "Custom label distinguishing specific partitions of the data space (segmentations or parcellations). Derivative data only. Corresponds to the seg-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "resolution",
+      "title": "Resolution",
+      "type": "string",
+      "format": "label",
+      "description": "Resolution of regularly sampled N-dimensional data. Derivative data only. Corresponds to the res-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "density",
+      "title": "Density",
+      "type": "string",
+      "format": "label",
+      "description": "Density of non-parametric surfaces. Derivative data only. Corresponds to the den-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "label",
+      "title": "Label",
+      "type": "string",
+      "format": "label",
+      "description": "Tissue-type label following a prescribed vocabulary, used for binary masks and probabilistic segmentations. Derivative data only. Corresponds to the label-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "description",
+      "title": "Description",
+      "type": "string",
+      "format": "label",
+      "description": "Free-form label used to distinguish two files that do not otherwise have a distinguishing entity. Derivative data only. Corresponds to the desc-<label> entity.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9]+$"
+      }
+    },
+    {
+      "name": "suffix",
+      "title": "Suffix",
+      "type": "string",
+      "description": "BIDS file suffix indicating the imaging modality or data type (for example, bold, T1w, dwi, events).",
+      "constraints": {
+        "required": true,
+        "enum": [
+          "2PE", "ADC", "BF", "CARS", "CONF", "Chimap", "DIC", "DF", "FA",
+          "FLAIR", "FLASH", "FLUO", "IRT1", "M0map", "MEGRE", "MESE",
+          "MP2RAGE", "MPE", "MPM", "MTR", "MTRmap", "MTS", "MTVmap", "MTsat",
+          "MWFmap", "NLO", "OCT", "PC", "PD", "PDT2", "PDmap", "PDw", "PLI",
+          "R1map", "R2map", "R2starmap", "RB1COR", "RB1map", "S0map", "SEM",
+          "SPIM", "SR", "T1map", "T1rho", "T1w", "T2map", "T2star",
+          "T2starmap", "T2starw", "T2w", "TB1AFI", "TB1DAM", "TB1EPI",
+          "TB1RFM", "TB1SRGE", "TB1TFL", "TB1map", "TEM", "UNIT1", "VFA",
+          "XPCT", "angio", "asl", "aslcontext", "asllabeling", "beh", "blood",
+          "bold", "cbv", "channels", "colFA", "coordsystem", "defacemask",
+          "descriptions", "dseg", "dwi", "eeg", "electrodes", "epi", "events",
+          "expADC", "fieldmap", "headshape", "ieeg", "inplaneT1", "inplaneT2",
+          "m0scan", "magnitude", "magnitude1", "magnitude2", "markers", "mask",
+          "meg", "motion", "mrsi", "mrsref", "nirs", "noRF", "optodes", "pet",
+          "phase", "phase1", "phase2", "phasediff", "photo", "physio",
+          "probseg", "sbref", "scans", "sessions", "stim", "svs", "trace",
+          "uCT", "unloc"
+        ]
+      }
+    },
+    {
+      "name": "extension",
+      "title": "Extension",
+      "type": "string",
+      "description": "File extension including the leading dot (for example, .nii.gz, .json, .tsv).",
+      "constraints": {
+        "required": true,
+        "enum": [
+          ".ave", ".bdf", ".bval", ".bvec", ".chn", ".con", ".dat", ".ds",
+          ".dlabel.nii", ".edf", ".eeg", ".fdt", ".fif", ".jpg", ".json",
+          ".kdf", ".label.gii", ".md", ".mefd", ".mhd", ".mrk", ".ome.zarr",
+          ".nii", ".nii.gz", ".nwb", ".ome.btf", ".ome.tif", ".png", ".pos",
+          ".raw", ".rst", ".set", ".snirf", ".sqd", ".tif", ".trg", ".tsv",
+          ".tsv.gz", ".txt", ".vhdr", ".vmrk"
+        ]
+      }
+    },
+    {
+      "name": "path",
+      "title": "File Path",
+      "type": "string",
+      "description": "Full file path to the BIDS data file.",
+      "constraints": {
+        "required": true,
+        "unique": true
+      }
+    }
+  ]
+}

--- a/table_schema.json
+++ b/table_schema.json
@@ -10,7 +10,10 @@
       "name": "derivatives",
       "title": "Derivative Pipeline",
       "type": "string",
-      "description": "Pipeline name extracted from the derivatives/ folder path. NA if the file is not in a derivatives directory."
+      "description": "Pipeline name extracted from the derivatives/ folder path. NA if the file is not in a derivatives directory.",
+      "constraints": {
+        "pattern": "^[a-zA-Z0-9_-]+$"
+      }
     },
     {
       "name": "data_type",
@@ -42,7 +45,7 @@
       "name": "subject",
       "title": "Subject",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "A person or animal participating in the study. Corresponds to the sub-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -52,7 +55,7 @@
       "name": "session",
       "title": "Session",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "A logical grouping of neuroimaging and behavioral data consistent across subjects. Corresponds to the ses-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -62,7 +65,7 @@
       "name": "sample",
       "title": "Sample",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "A sample pertaining to a subject such as tissue, primary cell, or cell-free sample. Corresponds to the sample-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -72,7 +75,7 @@
       "name": "task",
       "title": "Task",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "A set of structured activities performed by the participant. Corresponds to the task-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -82,7 +85,7 @@
       "name": "tracksys",
       "title": "Tracking System",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Tracking system used for motion data. Corresponds to the tracksys-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -92,7 +95,7 @@
       "name": "acquisition",
       "title": "Acquisition",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Custom label to distinguish a different set of parameters used for acquiring the same modality. Corresponds to the acq-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -102,7 +105,7 @@
       "name": "nucleus",
       "title": "Nucleus",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Nucleus or nuclei targeted by the acquisition, corresponding to DICOM Tag 0018,9100. Corresponds to the nuc-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -112,7 +115,7 @@
       "name": "volume",
       "title": "Volume of Interest",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Region or body part scanned, used to distinguish acquisitions localized to different regions. Corresponds to the voi-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -122,7 +125,7 @@
       "name": "ceagent",
       "title": "Contrast Enhancing Agent",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Contrast agent used to distinguish sequences using different contrast enhanced images. Corresponds to the ce-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -132,7 +135,7 @@
       "name": "tracer",
       "title": "Tracer",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Tracer used to distinguish sequences using different tracers. Corresponds to the trc-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -142,7 +145,7 @@
       "name": "stain",
       "title": "Stain",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Stain or antibody used for contrast enhancement in microscopy. Corresponds to the stain-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -152,7 +155,7 @@
       "name": "reconstruction",
       "title": "Reconstruction",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Reconstruction algorithm used (for example, MoCo for motion correction). Corresponds to the rec-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -162,7 +165,7 @@
       "name": "direction",
       "title": "Phase-Encoding Direction",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Phase-encoding direction used to distinguish different acquisitions (for example, AP, PA, LR, RL). Corresponds to the dir-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -172,7 +175,7 @@
       "name": "run",
       "title": "Run",
       "type": "string",
-      "format": "index",
+      "bidsType": "index",
       "description": "Run index distinguishing separate data acquisitions with the same parameters and entities. Nonnegative integer. Corresponds to the run-<index> entity.",
       "constraints": {
         "pattern": "^[0-9]+$"
@@ -182,7 +185,7 @@
       "name": "modality",
       "title": "Corresponding Modality",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Modality label for defacing masks, referencing the modality of the image being defaced. Corresponds to the mod-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -192,7 +195,7 @@
       "name": "echo",
       "title": "Echo",
       "type": "string",
-      "format": "index",
+      "bidsType": "index",
       "description": "Echo index distinguishing files acquired at different echo times. Nonnegative integer. Corresponds to the echo-<index> entity.",
       "constraints": {
         "pattern": "^[0-9]+$"
@@ -202,7 +205,7 @@
       "name": "flip",
       "title": "Flip Angle",
       "type": "string",
-      "format": "index",
+      "bidsType": "index",
       "description": "Flip angle index distinguishing files acquired at different flip angles. Nonnegative integer. Corresponds to the flip-<index> entity.",
       "constraints": {
         "pattern": "^[0-9]+$"
@@ -212,7 +215,7 @@
       "name": "inversion",
       "title": "Inversion Time",
       "type": "string",
-      "format": "index",
+      "bidsType": "index",
       "description": "Inversion time index distinguishing files acquired at different inversion times. Nonnegative integer. Corresponds to the inv-<index> entity.",
       "constraints": {
         "pattern": "^[0-9]+$"
@@ -222,7 +225,7 @@
       "name": "mtransfer",
       "title": "Magnetization Transfer",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Magnetization transfer state indicating presence or absence of an MT pulse. Corresponds to the mt-<label> entity.",
       "constraints": {
         "enum": ["on", "off"]
@@ -232,7 +235,7 @@
       "name": "part",
       "title": "Part",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Component of the complex MRI signal representation (magnitude, phase, real, or imaginary). Corresponds to the part-<label> entity.",
       "constraints": {
         "enum": ["mag", "phase", "real", "imag"]
@@ -242,7 +245,7 @@
       "name": "processing",
       "title": "Processed (on device)",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Processing variant performed on the device, analogous to rec for MR (for example, MaxFilter sss, tsss, trans). Corresponds to the proc-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -252,7 +255,7 @@
       "name": "hemisphere",
       "title": "Hemisphere",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Hemibrain described by the file. Corresponds to the hemi-<label> entity.",
       "constraints": {
         "enum": ["L", "R"]
@@ -262,7 +265,7 @@
       "name": "space",
       "title": "Space",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Coordinate system or reference image for interpreting spatial coordinates. Corresponds to the space-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -272,7 +275,7 @@
       "name": "split",
       "title": "Split",
       "type": "string",
-      "format": "index",
+      "bidsType": "index",
       "description": "Split index for long recordings that exceed file size limits (for example, 2GB .fif files). Nonnegative integer. Corresponds to the split-<index> entity.",
       "constraints": {
         "pattern": "^[0-9]+$"
@@ -282,7 +285,7 @@
       "name": "recording",
       "title": "Recording",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Label distinguishing continuous recording files from different instruments, sampling frequencies, or start times. Corresponds to the recording-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -292,7 +295,7 @@
       "name": "chunk",
       "title": "Chunk",
       "type": "string",
-      "format": "index",
+      "bidsType": "index",
       "description": "Chunk index distinguishing images of the same physical sample with different fields of view. Nonnegative integer. Corresponds to the chunk-<index> entity.",
       "constraints": {
         "pattern": "^[0-9]+$"
@@ -302,7 +305,7 @@
       "name": "segmentation",
       "title": "Segmentation",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Custom label distinguishing specific partitions of the data space (segmentations or parcellations). Derivative data only. Corresponds to the seg-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -312,7 +315,7 @@
       "name": "resolution",
       "title": "Resolution",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Resolution of regularly sampled N-dimensional data. Derivative data only. Corresponds to the res-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -322,7 +325,7 @@
       "name": "density",
       "title": "Density",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Density of non-parametric surfaces. Derivative data only. Corresponds to the den-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -332,7 +335,7 @@
       "name": "label",
       "title": "Label",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Tissue-type label following a prescribed vocabulary, used for binary masks and probabilistic segmentations. Derivative data only. Corresponds to the label-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -342,7 +345,7 @@
       "name": "description",
       "title": "Description",
       "type": "string",
-      "format": "label",
+      "bidsType": "label",
       "description": "Free-form label used to distinguish two files that do not otherwise have a distinguishing entity. Derivative data only. Corresponds to the desc-<label> entity.",
       "constraints": {
         "pattern": "^[a-zA-Z0-9]+$"
@@ -366,11 +369,12 @@
           "TB1RFM", "TB1SRGE", "TB1TFL", "TB1map", "TEM", "UNIT1", "VFA",
           "XPCT", "angio", "asl", "aslcontext", "asllabeling", "beh", "blood",
           "bold", "cbv", "channels", "colFA", "coordsystem", "defacemask",
-          "descriptions", "dseg", "dwi", "eeg", "electrodes", "epi", "events",
+          "description", "descriptions", "dseg", "dwi", "eeg", "electrodes",
+          "emg", "epi", "events",
           "expADC", "fieldmap", "headshape", "ieeg", "inplaneT1", "inplaneT2",
           "m0scan", "magnitude", "magnitude1", "magnitude2", "markers", "mask",
           "meg", "motion", "mrsi", "mrsref", "nirs", "noRF", "optodes", "pet",
-          "phase", "phase1", "phase2", "phasediff", "photo", "physio",
+          "phase", "phase1", "phase2", "phasediff", "photo", "physio", "physioevents",
           "probseg", "sbref", "scans", "sessions", "stim", "svs", "trace",
           "uCT", "unloc"
         ]

--- a/table_schema.json
+++ b/table_schema.json
@@ -174,11 +174,11 @@
     {
       "name": "run",
       "title": "Run",
-      "type": "string",
+      "type": "integer",
       "bidsType": "index",
       "description": "Run index distinguishing separate data acquisitions with the same parameters and entities. Nonnegative integer. Corresponds to the run-<index> entity.",
       "constraints": {
-        "pattern": "^[0-9]+$"
+        "minimum": 0
       }
     },
     {
@@ -194,31 +194,31 @@
     {
       "name": "echo",
       "title": "Echo",
-      "type": "string",
+      "type": "integer",
       "bidsType": "index",
       "description": "Echo index distinguishing files acquired at different echo times. Nonnegative integer. Corresponds to the echo-<index> entity.",
       "constraints": {
-        "pattern": "^[0-9]+$"
+        "minimum": 0
       }
     },
     {
       "name": "flip",
       "title": "Flip Angle",
-      "type": "string",
+      "type": "integer",
       "bidsType": "index",
       "description": "Flip angle index distinguishing files acquired at different flip angles. Nonnegative integer. Corresponds to the flip-<index> entity.",
       "constraints": {
-        "pattern": "^[0-9]+$"
+        "minimum": 0
       }
     },
     {
       "name": "inversion",
       "title": "Inversion Time",
-      "type": "string",
+      "type": "integer",
       "bidsType": "index",
       "description": "Inversion time index distinguishing files acquired at different inversion times. Nonnegative integer. Corresponds to the inv-<index> entity.",
       "constraints": {
-        "pattern": "^[0-9]+$"
+        "minimum": 0
       }
     },
     {
@@ -274,11 +274,11 @@
     {
       "name": "split",
       "title": "Split",
-      "type": "string",
+      "type": "integer",
       "bidsType": "index",
       "description": "Split index for long recordings that exceed file size limits (for example, 2GB .fif files). Nonnegative integer. Corresponds to the split-<index> entity.",
       "constraints": {
-        "pattern": "^[0-9]+$"
+        "minimum": 0
       }
     },
     {
@@ -294,11 +294,11 @@
     {
       "name": "chunk",
       "title": "Chunk",
-      "type": "string",
+      "type": "integer",
       "bidsType": "index",
       "description": "Chunk index distinguishing images of the same physical sample with different fields of view. Nonnegative integer. Corresponds to the chunk-<index> entity.",
       "constraints": {
-        "pattern": "^[0-9]+$"
+        "minimum": 0
       }
     },
     {
@@ -384,16 +384,16 @@
       "name": "extension",
       "title": "Extension",
       "type": "string",
-      "description": "File extension including the leading dot (for example, .nii.gz, .json, .tsv).",
+      "description": "File extension extracted from the filename (for example, nii.gz, json, tsv).",
       "constraints": {
         "required": true,
         "enum": [
-          ".ave", ".bdf", ".bval", ".bvec", ".chn", ".con", ".dat", ".ds",
-          ".dlabel.nii", ".edf", ".eeg", ".fdt", ".fif", ".jpg", ".json",
-          ".kdf", ".label.gii", ".md", ".mefd", ".mhd", ".mrk", ".ome.zarr",
-          ".nii", ".nii.gz", ".nwb", ".ome.btf", ".ome.tif", ".png", ".pos",
-          ".raw", ".rst", ".set", ".snirf", ".sqd", ".tif", ".trg", ".tsv",
-          ".tsv.gz", ".txt", ".vhdr", ".vmrk"
+          "ave", "bdf", "bval", "bvec", "chn", "con", "dat", "ds",
+          "dlabel.nii", "edf", "eeg", "fdt", "fif", "jpg", "json",
+          "kdf", "label.gii", "md", "mefd", "mhd", "mrk", "ome.zarr",
+          "nii", "nii.gz", "nwb", "ome.btf", "ome.tif", "png", "pos",
+          "raw", "rst", "set", "snirf", "sqd", "tif", "trg", "tsv",
+          "tsv.gz", "txt", "vhdr", "vmrk"
         ]
       }
     },


### PR DESCRIPTION
Define a comprehensive table_schema.json following the Frictionless Data Table Schema specification, enriched with metadata from the official BIDS schema (bids-standard/bids-schema). Includes titles, descriptions, format annotations (label/index), and constraints (enum, pattern, required, unique) for all 36 output fields.

Fixes #14 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new tabular data schema to standardize BIDS-like metadata for derivatives and raw files.
  * Provides built-in validation: required fields, allowed suffixes/extensions, label and numeric format checks, unique path primary key, and missing-value handling to improve data integrity and interoperability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->