### PR TITLE
Align with BIDS nomenclature and resync from schema (#21)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ for neuroimaging data. The design follows a pipeline pattern: functions accept a
 TSV string and return a processed TSV string.
 
 **Key characteristics:**
-- 807-line Bash library, functional/pipeline style
+- ~810-line Bash library, functional/pipeline style
 - AWK-based data processing for TSV filtering and column operations
 - Extensible custom entity support via JSON configurations
 - Zero-dependency core (`jq` optional, for JSON features and custom entities)
@@ -28,17 +28,17 @@ or run it directly.
 Directory tree → filename parsing → TSV table → filtering / extraction / iteration
                      ↓                   ↓
               glob patterns         AWK processing
-              (31 entities)        (column/row ops)
+              (35 entities)        (column/row ops)
 ```
 
 ### Core Parsing Flow
 
-1. **Pattern matching**: Bash extended-glob patterns match 31 standard BIDS
+1. **Pattern matching**: Bash extended-glob patterns match 35 standard BIDS
    entities (`sub`, `ses`, `task`, `run`, ...) plus suffixes and extensions.
 2. **Filename parsing**: regex-based entity extraction into associative arrays.
 3. **JSON sidecar matching**: exact filename matching only (no inheritance
    resolution).
-4. **Output**: TSV table with columns `derivatives`, `data_type`, one column per
+4. **Output**: TSV table with columns `derivatives`, `datatype`, one column per
    BIDS entity, `suffix`, `extension`, `path`.
 
 ### Pipeline (typical order)
@@ -52,29 +52,38 @@ Directory tree → filename parsing → TSV table → filtering / extraction / i
 
 ## Column Naming Convention (CRITICAL)
 
-Table columns use **FULL BIDS entity display names**, not the short keys used in
-filenames:
+BIDS nomenclature (per `schema.json`, `objects.entities`) distinguishes three things
+per entity — get these right:
 
-| filename key | column name      |
-|--------------|------------------|
-| `sub`        | `subject`        |
-| `ses`        | `session`        |
-| `acq`        | `acquisition`    |
-| `rec`        | `reconstruction` |
-| `dir`        | `direction`      |
-| `task`       | `task` (same)    |
-| `run`        | `run` (same)     |
+| concept              | schema source     | example   | used as            |
+|----------------------|-------------------|-----------|--------------------|
+| entity **key**       | `.name`           | `sub`     | filename token     |
+| entity **name**      | object key        | `subject` | **table column**   |
+| entity display name  | `.display_name`   | `Subject` | not used here      |
+
+Table columns use the entity **name** (the long form), not the entity **key** (the
+short token used in filenames):
+
+| entity key | column name (entity name) |
+|------------|---------------------------|
+| `sub`      | `subject`                 |
+| `ses`      | `session`                 |
+| `acq`      | `acquisition`             |
+| `rec`      | `reconstruction`          |
+| `dir`      | `direction`               |
+| `task`     | `task` (same)             |
+| `run`      | `run` (same)              |
 
 When passing column names to `--columns`, `--row-filter`, `--drop-na`, sort keys,
-or `libBIDSsh_table_column_to_array`, use the **column name** (e.g. `subject`).
-Passing a short key like `sub` will silently fail to match (it is neither a known
+or `libBIDSsh_table_column_to_array`, use the entity **name** (e.g. `subject`).
+Passing an entity key like `sub` will silently fail to match (it is neither a known
 column name nor a numeric index). Numeric column indices are also accepted.
 
 ### Core table structure
 
 Each row is one file. Columns:
 - `derivatives` — pipeline name if under a `derivatives/` folder, else `NA`
-- `data_type` — BIDS data type (`anat`, `func`, `dwi`, ...)
+- `datatype` — BIDS datatype (`anat`, `func`, `dwi`, ...)
 - BIDS entities — `subject`, `session`, `task`, `acquisition`, `run`, ...
 - `suffix` — file suffix (`bold`, `T1w`, `dwi`, ...)
 - `extension` — file extension
@@ -218,11 +227,11 @@ matching rows instead of keeping them.
 # Enable extended globbing
 shopt -s extglob nullglob globstar
 
-# Build BIDS entity patterns (31 standard entities, defined inline in the parser)
+# Build BIDS entity patterns (35 standard entities, defined inline in the parser)
 local entities=(
   "*(_sub-+([a-zA-Z0-9]))"
-  "*(_ses-+([a-zA-Z0-9]))"
-  # ... 29 more entities
+  "*(_tpl-+([a-zA-Z0-9]))"
+  # ... 33 more entities
 )
 
 # Find files
@@ -267,7 +276,7 @@ fi
 
 ### libBIDS.sh
 
-**Purpose**: Main library containing all functionality (807 lines).
+**Purpose**: Main library containing all functionality (~810 lines).
 
 **Approximate section map** (verify with `grep -n '^libBIDSsh_\|^_libBIDSsh_' libBIDS.sh`):
 - Version check + strict mode — top of file
@@ -301,8 +310,8 @@ to activate (the parser loads every `custom/*.json`).
 {
   "entities": [
     {
-      "name": "bp",
-      "display_name": "bodypart",
+      "key": "bp",
+      "name": "bodypart",
       "pattern": "*(_bp-+([a-zA-Z0-9]))"
     }
   ]
@@ -401,8 +410,8 @@ libBIDSsh_json_to_associative_array "file.json" metadata
 ### Adding custom entities
 
 1. Copy `custom/custom_entities.json.tpl` to `custom/custom_entities.json`.
-2. Define each entity's `name`, `display_name` (the column header), and `pattern`
-   (Bash extended-glob).
+2. Define each entity's `key` (short filename token), `name` (the column header),
+   and `pattern` (Bash extended-glob).
 3. Source the library and call `libBIDSsh_parse_bids_to_table`; custom entities are
    appended after the standard ones.
 
@@ -432,7 +441,7 @@ libBIDSsh_json_to_associative_array "file.json" metadata
 1. **Understand BIDS** — see the [BIDS specification](https://bids-specification.readthedocs.io/).
 2. **Read README.md** — usage overview and full API reference.
 3. **Read libBIDS.sh** — inline docstrings document every function and its args.
-4. **Mind the column-naming convention** — full display names, not short keys.
+4. **Mind the column-naming convention** — entity names (e.g. `subject`), not entity keys (e.g. `sub`).
 5. **Test manually** — run against `bids-examples/` datasets to verify changes.
 6. **Check custom entities** — review `custom/custom_entities.json.tpl`.
 </content>

--- a/README.md
+++ b/README.md
@@ -52,16 +52,19 @@ table_data=$(libBIDSsh_parse_bids_to_table "bids-examples/ds001")
 
 **Output columns:**
 
-The TSV columns use the full BIDS entity names (display names), not the short keys found in filenames.
+The TSV columns use the full BIDS entity **names** (e.g. `subject`), not the entity
+**keys** (the short tokens like `sub` found in filenames). In BIDS schema terms the
+key is the entity's `.name` field (`sub`) and the column header is the entity object
+name (`subject`).
 
 - `derivatives`: Pipeline name if in derivatives folder
-- `data_type`: BIDS data type (anat, func, dwi, etc.)
-- BIDS entities: `subject` (not sub), `session` (not ses), `task`, `acquisition` (not acq), `run`, etc.
+- `datatype`: BIDS datatype (anat, func, dwi, etc.)
+- BIDS entities: `subject` (key `sub`), `session` (key `ses`), `task`, `acquisition` (key `acq`), `run`, etc.
 - `suffix`: File suffix (bold, T1w, dwi, etc.)
 - `extension`: File extension
 - `path`: Full file path
 
-**Note:** When filtering or accessing columns, always use these full names (e.g., `subject`, `session`, `acquisition`).
+**Note:** When filtering or accessing columns, always use these entity names (e.g., `subject`, `session`, `acquisition`).
 
 ## Filtering and Subsetting
 
@@ -233,10 +236,10 @@ _libBIDSsh_parse_filename "sub-01_task-rest_bold.nii.gz" file_info
 
 **Populated fields:**
 
-- Individual BIDS entities using short keys (`sub`, `ses`, `task`, `acq`, etc.)
+- Individual BIDS entities using entity keys (`sub`, `ses`, `task`, `acq`, etc.)
 - `suffix`: File suffix
 - `extension`: File extension
-- `data_type`: Inferred data type
+- `datatype`: Inferred datatype
 - `derivatives`: Pipeline name if applicable
 - `path`: Full path
 - `_key_order`: Order of keys for iteration
@@ -276,7 +279,7 @@ table_data=$(libBIDSsh_parse_bids_to_table "$bids_path")
 
 # Filter for functional BOLD data
 func_table=$(libBIDSsh_table_filter "$table_data" \
-  -r "data_type:func" \
+  -r "datatype:func" \
   -r "suffix:bold")
 
 # Add JSON paths
@@ -300,19 +303,19 @@ done
 
 ### Adding non-BIDS entities 
 
-If your dataset uses an entity that is not part of the official BIDS specification, you can include them in the parsing logic via JSON file(s) in the `custom` directory:
+If your dataset uses an entity that is not part of the official BIDS specification, you can include them in the parsing logic via JSON file(s) in the `custom` directory. Each entity object uses `key` (the short filename token), `name` (the long column header), and `pattern` (a bash extended-glob):
 
 ```json
 {
   "entities": [
     {
-      "name": "foo",
-      "display_name": "fooval",
+      "key": "foo",
+      "name": "fooval",
       "pattern": "*(_foo-+([a-zA-Z0-9]))"
     },
     {
-      "name": "bar",
-      "display_name": "baridx",
+      "key": "bar",
+      "name": "baridx",
       "pattern": "*(_bar-+([0-9]))"
     }
     ...

--- a/custom/custom_entities.json.tpl
+++ b/custom/custom_entities.json.tpl
@@ -1,8 +1,8 @@
 {
   "entities": [
     {
-      "name": "bp",
-      "display_name": "bodypart",
+      "key": "bp",
+      "name": "bodypart",
       "pattern": "*(_bp-+([a-zA-Z0-9]))"
     }
   ]

--- a/generate_entity_patterns.sh
+++ b/generate_entity_patterns.sh
@@ -1,25 +1,57 @@
 #!/usr/bin/env bash
 
+# Regenerate every schema-derived block used by libBIDS.sh from schema.json.
+# schema.json is the authoritative BIDS specification source; treat it as the
+# single source of truth and paste the blocks below into libBIDS.sh verbatim.
+#
+# BIDS nomenclature (see schema objects.entities):
+#   entity key  = schema .name        (e.g. "sub")  -> filename token
+#   entity name = schema object key   (e.g. "subject") -> table column header
+# rules.entities provides the canonical filename ordering of entities.
+
 set -euo pipefail
 
-entities_order=($(jq -r .rules.entities.[] schema.json))
-entities_names_ordered=()
+# Entities, in canonical BIDS filename order (rules.entities).
+mapfile -t entity_names < <(jq -r '.rules.entities[]' schema.json)
+entity_keys=()
 
-for entity in ${entities_order[@]}; do
-  entity_name=$(jq -r .objects.entities.${entity}.name schema.json)
-  entities_names_ordered+=(${entity_name})
-  entity_format=$(jq -r .objects.entities.${entity}.format schema.json)
+echo "### entities=( ) glob patterns ###"
+for entity in "${entity_names[@]}"; do
+  entity_key=$(jq -r ".objects.entities.${entity}.name" schema.json)
+  entity_keys+=("${entity_key}")
+  entity_format=$(jq -r ".objects.entities.${entity}.format" schema.json)
   if [[ ${entity_format} == "label" ]]; then
-    echo \""*(_${entity_name}-+([a-zA-Z0-9]))"\"
+    echo "    \"*(_${entity_key}-+([a-zA-Z0-9]))\""
   elif [[ ${entity_format} == "index" ]]; then
-    echo \""*(_${entity_name}-+([0-9]))"\"
+    echo "    \"*(_${entity_key}-+([0-9]))\""
   else
     echo "Unrecognized entity_format ${entity_format}" 1>&2
     exit 1
   fi
 done
 
-printf "%s," ${entities_order[@]}
 echo
-printf "%s " ${entities_names_ordered[@]}
+echo "### entities_order (entity keys, space separated) ###"
+printf "%s " "${entity_keys[@]}"
 echo
+
+echo
+echo "### entities_name_order (entity names / column headers, tab separated) ###"
+printf "%s" "${entity_names[0]}"
+printf "\\\\t%s" "${entity_names[@]:1}"
+echo
+
+echo
+echo "### suffixes alternation ###"
+printf '_@(%s)\n' "$(jq -r '.objects.suffixes[].value' schema.json | paste -sd'|')"
+
+echo
+echo "### extensions alternation (drops '.*' and '/', strips trailing '/') ###"
+printf '@(%s)\n' "$(jq -r '.objects.extensions[].value' schema.json \
+  | grep -vxF -e '.*' -e '/' -e '' \
+  | sed 's:/$::' \
+  | paste -sd'|')"
+
+echo
+echo "### datatype regex (for _libBIDSsh_parse_filename) ###"
+printf '(%s)\n' "$(jq -r '.objects.datatypes | keys[]' schema.json | paste -sd'|')"

--- a/libBIDS.sh
+++ b/libBIDS.sh
@@ -17,7 +17,7 @@ libBIDSsh_table_filter() {
   #   -d, --drop-na <list>      Comma-separated list of columns to check for NA values
   # Returns: Filtered TSV data through stdout
   # Example:
-  #   filtered=$(libBIDSsh_table_filter "$data" -c "sub,ses" -r "task:rest" -d "run")
+  #   filtered=$(libBIDSsh_table_filter "$data" -c "subject,session" -r "task:rest" -d "run")
   local table_data="$1"
   shift
 
@@ -247,8 +247,8 @@ _libBIDSsh_parse_filename() {
   arr[path]=$(tr -s / <<<"${path}")
   arr[extension]="${filename#*.}"
   # Extract from schema
-  # jq -r .objects.datatypes.[].value schema.json  | paste -s -d'|'
-  arr[data_type]=$(grep -o -E "(anat|beh|dwi|eeg|fmap|func|ieeg|meg|micr|motion|mrs|perf|pet|phenotype|nirs)" <<<"$(dirname "${path}")" | head -1 || echo "NA")
+  # ./generate_entity_patterns.sh -> datatype regex
+  arr[datatype]=$(grep -o -E "(anat|beh|dwi|eeg|emg|fmap|func|ieeg|meg|micr|motion|mrs|nirs|perf|pet|phenotype)" <<<"$(dirname "${path}")" | head -1 || echo "NA")
   arr[derivatives]=$(grep -o 'derivatives/.*/' <<<"${path}" | awk -F/ '{print $2}' || echo "NA")
 
   local name_no_ext="${filename%%.*}"
@@ -273,7 +273,7 @@ _libBIDSsh_parse_filename() {
 
   key_order+=("suffix")
   key_order+=("extension")
-  key_order+=("data_type")
+  key_order+=("datatype")
   key_order+=("derivatives")
   key_order+=("path")
 
@@ -366,8 +366,8 @@ _libBIDSsh_load_custom_entities() {
   # Load custom entities from JSON configuration files
   # JSON files should be placed in ./custom directory
   # Each JSON file should contain an "entities" array with objects having:
-  #   - name: entity short name
-  #   - display_name: entity display name for table headers
+  #   - key: entity key, the short filename token (e.g. "bp")
+  #   - name: entity name, the long table column header (e.g. "bodypart")
   #   - pattern: bash glob pattern for matching
 
   local script_dir
@@ -383,14 +383,14 @@ _libBIDSsh_load_custom_entities() {
     declare -gA CUSTOM_ENTITIES
   fi
   CUSTOM_ENTITIES=()
+  if [[ -z "${CUSTOM_ENTITY_KEYS+x}" ]]; then
+    declare -ga CUSTOM_ENTITY_KEYS
+  fi
+  CUSTOM_ENTITY_KEYS=()
   if [[ -z "${CUSTOM_ENTITY_NAMES+x}" ]]; then
     declare -ga CUSTOM_ENTITY_NAMES
   fi
   CUSTOM_ENTITY_NAMES=()
-  if [[ -z "${CUSTOM_ENTITY_DISPLAY_NAMES+x}" ]]; then
-    declare -ga CUSTOM_ENTITY_DISPLAY_NAMES
-  fi
-  CUSTOM_ENTITY_DISPLAY_NAMES=()
 
   if [[ ! -d "$plugin_dir" ]]; then
     return 0
@@ -413,14 +413,14 @@ _libBIDSsh_load_custom_entities() {
   for json_file in "${json_files[@]}"; do
     if [[ -f "$json_file" ]]; then
       # Parse JSON and extract entity definitions
-      while IFS=';' read -r name display_name pattern; do
-        if [[ -n "$name" && -n "$display_name" && -n "$pattern" ]]; then
-          CUSTOM_ENTITIES["$name"]="$pattern"
+      while IFS=';' read -r key name pattern; do
+        if [[ -n "$key" && -n "$name" && -n "$pattern" ]]; then
+          CUSTOM_ENTITIES["$key"]="$pattern"
+          CUSTOM_ENTITY_KEYS+=("$key")
           CUSTOM_ENTITY_NAMES+=("$name")
-          CUSTOM_ENTITY_DISPLAY_NAMES+=("$display_name")
         fi
       done < <(
-        jq -r '.entities[] | "\(.name);\(.display_name);\(.pattern)"' \
+        jq -r '.entities[] | "\(.key);\(.name);\(.pattern)"' \
           "$json_file" 2>/dev/null
       )
     fi
@@ -450,7 +450,9 @@ libBIDSsh_parse_bids_to_table() {
   # Extracted from schema with generate_entity_patterns.sh
   local entities=(
     "*(_sub-+([a-zA-Z0-9]))"
+    "*(_tpl-+([a-zA-Z0-9]))"
     "*(_ses-+([a-zA-Z0-9]))"
+    "*(_cohort-+([a-zA-Z0-9]))"
     "*(_sample-+([a-zA-Z0-9]))"
     "*(_task-+([a-zA-Z0-9]))"
     "*(_tracksys-+([a-zA-Z0-9]))"
@@ -475,7 +477,9 @@ libBIDSsh_parse_bids_to_table() {
     "*(_split-+([0-9]))"
     "*(_recording-+([a-zA-Z0-9]))"
     "*(_chunk-+([0-9]))"
+    "*(_atlas-+([a-zA-Z0-9]))"
     "*(_seg-+([a-zA-Z0-9]))"
+    "*(_scale-+([a-zA-Z0-9]))"
     "*(_res-+([a-zA-Z0-9]))"
     "*(_den-+([a-zA-Z0-9]))"
     "*(_label-+([a-zA-Z0-9]))"
@@ -489,7 +493,7 @@ libBIDSsh_parse_bids_to_table() {
 
   # Suffixes from schema.json
   # jq -r .objects.suffixes.[].value schema.json | paste -s -d'|'
-  local suffixes="_@(2PE|ADC|BF|Chimap|CARS|CONF|DIC|DF|FA|FLAIR|FLASH|FLUO|IRT1|M0map|MEGRE|MESE|MP2RAGE|MPE|MPM|MTR|MTRmap|MTS|MTVmap|MTsat|MWFmap|NLO|OCT|PC|PD|PDT2|PDmap|PDw|PLI|R1map|R2map|R2starmap|RB1COR|RB1map|S0map|SEM|SPIM|SR|T1map|T1rho|T1w|T2map|T2star|T2starmap|T2starw|T2w|TB1AFI|TB1DAM|TB1EPI|TB1RFM|TB1SRGE|TB1TFL|TB1map|TEM|UNIT1|VFA|angio|asl|aslcontext|asllabeling|beh|blood|bold|cbv|channels|colFA|coordsystem|defacemask|descriptions|dseg|dwi|eeg|electrodes|epi|events|expADC|fieldmap|headshape|XPCT|ieeg|inplaneT1|inplaneT2|m0scan|magnitude|magnitude1|magnitude2|markers|mask|meg|motion|mrsi|mrsref|nirs|noRF|optodes|pet|phase|phase1|phase2|phasediff|photo|physio|probseg|sbref|scans|sessions|stim|svs|trace|uCT|unloc)"
+  local suffixes="_@(2PE|ADC|BF|Chimap|CARS|CONF|DIC|DF|FA|FLAIR|FLASH|FLUO|IRT1|M0map|MEGRE|MESE|MP2RAGE|MPE|MPM|MTR|MTRmap|MTS|MTVmap|MTsat|MWFmap|NLO|OCT|PC|PD|PDT2|PDmap|PDw|PLI|R1map|R2map|R2starmap|RB1COR|RB1map|S0map|SEM|SPIM|SR|T1map|T1rho|T1w|T2map|T2star|T2starmap|T2starw|T2w|TB1AFI|TB1DAM|TB1EPI|TB1RFM|TB1SRGE|TB1TFL|TB1map|TEM|UNIT1|VFA|angio|asl|aslcontext|asllabeling|beh|blood|bold|cbv|channels|colFA|coordsystem|defacemask|description|descriptions|dseg|dwi|eeg|electrodes|emg|epi|events|expADC|fieldmap|headshape|XPCT|ieeg|inplaneT1|inplaneT2|m0scan|magnitude|magnitude1|magnitude2|markers|mask|meg|motion|mrsi|mrsref|nirs|noRF|optodes|pet|phase|phase1|phase2|phasediff|photo|physio|physioevents|probseg|sbref|scans|sessions|stim|svs|trace|uCT|unloc)"
 
   # Allowed extensions
   # jq -r .objects.extensions.[].value schema.json | paste -s -d'|'
@@ -515,24 +519,26 @@ libBIDSsh_parse_bids_to_table() {
   shopt -u nullglob
   shopt -u globstar
 
-  # Order of entities from generate_entity_patterns.sh
-  entities_displayname_order=$'subject\tsession\tsample\ttask\ttracksys\tacquisition\tnucleus\tvolume\tceagent\ttracer\tstain\treconstruction\tdirection\trun\tmodality\techo\tflip\tinversion\tmtransfer\tpart\tprocessing\themisphere\tspace\tsplit\trecording\tchunk\tsegmentation\tresolution\tdensity\tlabel\tdescription'
-  entities_order="sub ses sample task tracksys acq nuc voi ce trc stain rec dir run mod echo flip inv mt part proc hemi space split recording chunk seg res den label desc"
+  # Order of entities from generate_entity_patterns.sh.
+  # entities_order holds entity keys (filename tokens); entities_name_order holds
+  # entity names (the long, canonical column headers). Both in canonical BIDS order.
+  entities_name_order=$'subject\ttemplate\tsession\tcohort\tsample\ttask\ttracksys\tacquisition\tnucleus\tvolume\tceagent\ttracer\tstain\treconstruction\tdirection\trun\tmodality\techo\tflip\tinversion\tmtransfer\tpart\tprocessing\themisphere\tspace\tsplit\trecording\tchunk\tatlas\tsegmentation\tscale\tresolution\tdensity\tlabel\tdescription'
+  entities_order="sub tpl ses cohort sample task tracksys acq nuc voi ce trc stain rec dir run mod echo flip inv mt part proc hemi space split recording chunk atlas seg scale res den label desc"
 
   # Add custom entities to ordering
+  for entity_key in "${CUSTOM_ENTITY_KEYS[@]}"; do
+    entities_order+=" $entity_key"
+  done
+
   for entity_name in "${CUSTOM_ENTITY_NAMES[@]}"; do
-    entities_order+=" $entity_name"
+    entities_name_order+=$'\t'"$entity_name"
   done
 
-  for entity_display in "${CUSTOM_ENTITY_DISPLAY_NAMES[@]}"; do
-    entities_displayname_order+=$'\t'"$entity_display"
-  done
-
-  printf "derivatives\tdata_type\t%s\tsuffix\textension\tpath\n" "${entities_displayname_order}"
+  printf "derivatives\tdatatype\t%s\tsuffix\textension\tpath\n" "${entities_name_order}"
   for file in "${files[@]}"; do
     declare -A file_info
     _libBIDSsh_parse_filename "${file}" file_info
-    for key in derivatives data_type ${entities_order} suffix extension path; do
+    for key in derivatives datatype ${entities_order} suffix extension path; do
       if [[ "${file_info[${key}]+abc}" ]]; then
         printf '%s\t' "${file_info[${key}]}"
       else
@@ -554,7 +560,7 @@ libBIDSsh_table_column_to_array() {
   #   exclude_NA: (optional) "true" to exclude NA values (default: true)
   # Example:
   #   declare -a subjects
-  #   libBIDSsh_table_column_to_array "$data" "sub" subjects true true
+  #   libBIDSsh_table_column_to_array "$data" "subject" subjects true true
   local table_data="$1"
   local column="$2"
   local -n array_ref="$3" # nameref to the array variable
@@ -621,8 +627,8 @@ libBIDSsh_table_iterator() {
   # Returns: 0 for success (more rows), 1 when done
   # Example:
   #   declare -A row
-  #   while libBIDSsh_table_iterator "$data" row "sub" "ses" "-r"; do
-  #     echo "Processing subject ${row[sub]} session ${row[ses]}"
+  #   while libBIDSsh_table_iterator "$data" row "subject" "session" "-r"; do
+  #     echo "Processing subject ${row[subject]} session ${row[session]}"
   #   done
   local table_var="${1:-}" # Name of the variable containing table data
   if [[ -z "${2:-}" ]]; then


### PR DESCRIPTION
Closes #21.

Audits the library against `bids-schema`/`bids-specification` (vendored `schema.json`) and makes code **and** docs use BIDS-correct terms, while treating `schema.json` as the single source of truth for the generated lists.

## Nomenclature
- Rename the `data_type` column/key to **`datatype`** (BIDS is consistently one word: `objects.datatypes`).
- Distinguish the three schema concepts and stop calling the column headers "display names":
  | concept | schema source | example | use |
  |---|---|---|---|
  | entity **key** | `.name` | `sub` | filename token |
  | entity **name** | object key | `subject` | **table column** |
  | entity display name | `.display_name` | `Subject` | not used here |
- Custom-entity JSON fields are now `key` / `name` / `pattern` (was `name` / `display_name` / `pattern`); internal arrays renamed to `CUSTOM_ENTITY_{KEYS,NAMES}`. **Breaking** for existing `custom/*.json`.
- Fix docstring examples that passed entity keys (`"sub,ses"`) which silently fail the column matcher.

## Schema resync
- `generate_entity_patterns.sh` now emits **every** machine-generated block (entity patterns, key/name order, suffixes, extensions, datatype regex) so regeneration is one command.
- Add 4 missing entities in canonical order: **`template`, `cohort`, `atlas`, `scale`** (31 → 35).
- Add missing datatype **`emg`** — bug fix: emg files previously parsed as `datatype=NA`.
- Add missing suffixes: **`description`, `emg`, `physioevents`**.

## Breaking changes
- `data_type` → `datatype` column (update any scripts filtering/accessing it).
- Custom-entity config field rename (`name`→`key`, `display_name`→`name`).

## Verification
- `bash -n` + `shellcheck` clean on both scripts.
- `./test_libBIDS.sh` → 8/8 pass.
- Clean-subprocess parse: `datatype=emg` resolves; `anat`/`func` unchanged.
- Custom entity with `key`/`name` produces the `bodypart` column (value `bp-leg`).

## Out of scope (follow-up)
`grep … | head -1 || echo "NA"` in `_libBIDSsh_parse_filename` is fragile under `set -o pipefail` (SIGPIPE → NA fallback). Pre-existing; consider `grep -m1` later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified column naming conventions to use full entity names (e.g., `subject` instead of `sub`)
  * Renamed `data_type` column to `datatype` for consistency
  * Updated custom entity configuration schema

* **New Features**
  * Added support for 4 new BIDS entities: template, cohort, atlas, and scale
  * Extended entity parsing coverage from 31 to 35 entities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->