### PR TITLE
Add .bidsignore support to the parser

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,12 +43,14 @@ Directory tree → filename parsing → TSV table → filtering / extraction / i
 
 ### Pipeline (typical order)
 
-1. **Parse**: `libBIDSsh_parse_bids_to_table` — BIDS directory → TSV
-2. *(optional)* `libBIDSsh_extension_json_rows_to_column_json_path` — link JSON sidecars
-3. *(optional)* `libBIDSsh_drop_na_columns` — remove all-NA columns
-4. **Filter**: `libBIDSsh_table_filter` — keep columns / filter rows / drop NA
-5. **Extract**: `libBIDSsh_table_column_to_array` — column → Bash array
-6. **Iterate**: `libBIDSsh_table_iterator` — row-by-row with sorting
+1. **Parse**: `libBIDSsh_parse_bids_to_table` — BIDS directory → TSV (honors
+   `.bidsignore` by default; `--no-bidsignore` / `--no-default-ignores` to opt out)
+2. *(optional)* `libBIDSsh_apply_bidsignore` — drop rows excluded by `.bidsignore`
+3. *(optional)* `libBIDSsh_extension_json_rows_to_column_json_path` — link JSON sidecars
+4. *(optional)* `libBIDSsh_drop_na_columns` — remove all-NA columns
+5. **Filter**: `libBIDSsh_table_filter` — keep columns / filter rows / drop NA
+6. **Extract**: `libBIDSsh_table_column_to_array` — column → Bash array
+7. **Iterate**: `libBIDSsh_table_iterator` — row-by-row with sorting
 
 ## Column Naming Convention (CRITICAL)
 
@@ -90,20 +92,25 @@ Each row is one file. Columns:
 - `path` — full file path
 - *(optional)* `json_path` — added by `..._json_rows_to_column_json_path`
 
-### Public API (7 functions)
+### Public API (8 functions)
 
-- `libBIDSsh_parse_bids_to_table` — core BIDS parser, main entry point
+- `libBIDSsh_parse_bids_to_table` — core BIDS parser, main entry point (honors
+  `.bidsignore` by default; `--no-bidsignore` / `--no-default-ignores` flags)
 - `libBIDSsh_table_filter` — AWK-based TSV filtering (columns, rows, drop-na, invert)
 - `libBIDSsh_drop_na_columns` — remove columns whose values are all `NA`
+- `libBIDSsh_apply_bidsignore` — drop rows excluded by a dataset's `.bidsignore`
 - `libBIDSsh_extension_json_rows_to_column_json_path` — fold JSON sidecar rows into a `json_path` column
 - `libBIDSsh_table_column_to_array` — TSV column → Bash array
 - `libBIDSsh_table_iterator` — iterate TSV rows into an associative array, with sorting
 - `libBIDSsh_json_to_associative_array` — parse a JSON file into a Bash associative array
 
-### Internal Functions (2)
+### Internal Functions (5)
 
 - `_libBIDSsh_parse_filename` — regex-based entity extraction from a filename
 - `_libBIDSsh_load_custom_entities` — load custom entity definitions from `custom/*.json`
+- `_libBIDSsh_compile_bidsignore_line` — compile one gitignore-style pattern to an anchored ERE
+- `_libBIDSsh_compile_bidsignore` — compile default ignores + root `.bidsignore` into match arrays
+- `_libBIDSsh_path_is_ignored` — test a dataset-relative path against the compiled patterns (last-match-wins)
 
 ## Key Directories
 
@@ -435,6 +442,12 @@ libBIDSsh_json_to_associative_array "file.json" metadata
 3. **JSON sidecars** — `..._json_rows_to_column_json_path` matches only a JSON file
    with the exact same name (different extension); no inheritance hierarchy resolution.
 4. **Malformed custom entities** — can cause runtime errors.
+5. **`.bidsignore`** — only the **root-level** `.bidsignore` is read (no inheritance /
+   nested files, matching `bids-validator`). Negation (`!`) does not specially block
+   re-including a file under an already-excluded parent directory — each file's full
+   relative path is tested independently. Escaped trailing whitespace (`\ `) is the
+   one gitignore corner not fully honored. Because the parser only globs valid-BIDS
+   suffix+extension files, `.bidsignore` patterns targeting non-BIDS files are no-ops.
 
 ## Start Here (for AI assistants)
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Parses a directory tree, identifies BIDS files, extracts BIDS entities, and outp
 table_data=$(libBIDSsh_parse_bids_to_table "bids-examples/ds001")
 ```
 
+**Options:**
+
+- `--no-bidsignore`: Do not honor the dataset's `.bidsignore` file or the built-in default ignores (parse every BIDS-shaped file).
+- `--no-default-ignores`: Honor the dataset's `.bidsignore` but skip the built-in default ignores (`sourcedata/`, `code/`, `stimuli/`, `log/`, dotfiles, `.git`).
+
+By default the parser honors a root-level `.bidsignore` and the built-in default
+ignores (see [`.bidsignore` support](#bidsignore-support) below).
+
 **Output columns:**
 
 The TSV columns use the full BIDS entity **names** (e.g. `subject`), not the entity
@@ -116,6 +124,59 @@ cleaned=$(libBIDSsh_drop_na_columns "$table_data")
 # Remove empty columns from dataset
 table_data=$(libBIDSsh_parse_bids_to_table "bids-examples/ds001")
 cleaned=$(libBIDSsh_drop_na_columns "$table_data")
+```
+
+## `.bidsignore` support
+
+A BIDS dataset may carry a root-level [`.bidsignore`](https://bids-specification.readthedocs.io/en/stable/derivatives/introduction.html#bidsignore)
+file listing **gitignore-style patterns** for files that are not part of the BIDS
+standard. `libBIDSsh_parse_bids_to_table` honors it by default and also applies a
+built-in list of default ignores, matching the behavior of `bids-validator`.
+
+**Built-in default ignores:** `.git**`, `.*` (dotfiles), `sourcedata/`, `code/`,
+`stimuli/`, `log/`. Note that `derivatives/` is intentionally **not** ignored —
+libBIDS.sh treats derivatives as first-class data.
+
+**Supported gitignore syntax:** blank lines and `#` comments; `*` and `?` (which do
+not cross `/`); `**` whole-segment globstar (crosses directories); `[...]` bracket
+expressions; `\`-escapes; leading/embedded `/` to anchor a pattern to the dataset
+root; trailing `/` for directory-only matches; and `!` negation (re-include) with
+last-match-wins ordering.
+
+**Limitations:** only the root-level `.bidsignore` is read (no inheritance / nested
+files, matching `bids-validator`). Because the parser only ever globs files whose
+suffix and extension are valid BIDS tokens, `.bidsignore` patterns that target
+non-BIDS files (e.g. `*.html`) are effectively no-ops — the parser never picked
+those files up. `.bidsignore` becomes meaningful for BIDS-shaped files an author
+explicitly excludes (e.g. `**/sub-*_..._FLASH.nii.gz`).
+
+```bash
+# Honor .bidsignore + defaults (the default behavior)
+table_data=$(libBIDSsh_parse_bids_to_table "path/to/dataset")
+
+# Parse everything, ignoring .bidsignore entirely
+raw=$(libBIDSsh_parse_bids_to_table --no-bidsignore "path/to/dataset")
+
+# Honor .bidsignore but keep sourcedata/, code/, etc.
+table_data=$(libBIDSsh_parse_bids_to_table --no-default-ignores "path/to/dataset")
+```
+
+### `libBIDSsh_apply_bidsignore`
+
+Applies a dataset's `.bidsignore` (and, by default, the built-in default ignores) to
+an already-parsed table, dropping rows whose file is excluded. Useful for filtering
+a table that was parsed with `--no-bidsignore`, or one obtained from another source.
+
+```bash
+filtered=$(libBIDSsh_apply_bidsignore "$table_data" "path/to/dataset" [--no-default-ignores])
+```
+
+**Example:**
+
+```bash
+raw=$(libBIDSsh_parse_bids_to_table --no-bidsignore "path/to/dataset")
+# ... inspect or process the unfiltered table ...
+filtered=$(libBIDSsh_apply_bidsignore "$raw" "path/to/dataset")
 ```
 
 ## JSON Processing

--- a/libBIDS.sh
+++ b/libBIDS.sh
@@ -707,6 +707,19 @@ libBIDSsh_parse_bids_to_table() {
       --no-bidsignore) honor_bidsignore=0; shift ;;
       --default-ignores) use_defaults=1; shift ;;
       --no-default-ignores) use_defaults=0; shift ;;
+      --)
+        # End of options: everything after is positional (allows a path like "-x").
+        shift
+        while [[ $# -gt 0 ]]; do
+          if [[ -z "$bidspath" ]]; then
+            bidspath="$1"
+          else
+            echo "Error: unexpected extra argument '$1'" >&2
+            return 1
+          fi
+          shift
+        done
+        ;;
       -*) echo "Unknown option: $1" >&2; return 1 ;;
       *)
         if [[ -z "$bidspath" ]]; then

--- a/libBIDS.sh
+++ b/libBIDS.sh
@@ -445,13 +445,280 @@ _libBIDSsh_load_custom_entities() {
   shopt -u nullglob
 }
 
+# shellcheck disable=SC2154
+_libBIDSsh_compile_bidsignore_line() {
+  # Compile one gitignore-style pattern into an anchored ERE and append it to the
+  # module-level _LIBBIDSSH_BIDSIGNORE_REGEX / _LIBBIDSSH_BIDSIGNORE_NEG arrays.
+  # Blank lines and comments are skipped. Implements the gitignore subset:
+  #   - leading '!'        -> negation (re-include), recorded in the NEG array
+  #   - leading/embedded / -> anchored to the dataset root
+  #   - trailing /         -> directory-only match
+  #   - '**' as a whole path segment spans directories; '*' and '?' do not
+  #   - '[...]' bracket expressions and '\'-escapes are passed through
+  # Usage: _libBIDSsh_compile_bidsignore_line "<pattern>"
+  local line="$1"
+
+  # Strip a trailing carriage return (CRLF files).
+  line="${line%$'\r'}"
+  [[ -z "$line" ]] && return 0
+
+  # Strip unescaped trailing whitespace (an escaped '\ ' trailing space is kept).
+  while [[ "$line" == *[[:space:]] && "$line" != *'\'[[:space:]] ]]; do
+    line="${line%?}"
+  done
+  [[ -z "$line" ]] && return 0
+
+  # Escapes, comments and negation at the start of the pattern.
+  local negated=0
+  case "$line" in
+    '\#'* | '\!'*) line="${line#\\}" ;; # literal leading '#' or '!'
+    '#'*) return 0 ;;                    # comment
+    '!'*)
+      negated=1
+      line="${line#!}"
+      ;;
+  esac
+  [[ -z "$line" ]] && return 0
+
+  # Trailing slash => directory-only match.
+  local dir_only=0
+  if [[ "$line" == */ ]]; then
+    dir_only=1
+    line="${line%/}"
+  fi
+  [[ -z "$line" ]] && return 0
+
+  # A '/' at the start or middle anchors the pattern to the dataset root.
+  local anchored=0
+  if [[ "$line" == /* ]]; then
+    anchored=1
+    line="${line#/}"
+  elif [[ "$line" == */* ]]; then
+    anchored=1
+  fi
+  [[ -z "$line" ]] && return 0
+
+  # Translate the glob body into an ERE, character by character.
+  local core="" i=0 n=${#line} c nc
+  while ((i < n)); do
+    c="${line:i:1}"
+    if [[ "$c" == '\' ]]; then
+      # Backslash escapes the next character -> emit it literally.
+      nc="${line:i+1:1}"
+      if [[ -n "$nc" ]]; then
+        case "$nc" in
+          '.' | '^' | '$' | '+' | '(' | ')' | '{' | '}' | '|' | '[' | ']' | '*' | '?' | '\')
+            core+="\\$nc" ;;
+          *) core+="$nc" ;;
+        esac
+        i=$((i + 2))
+      else
+        core+='\\'
+        i=$((i + 1))
+      fi
+      continue
+    fi
+    if [[ "$c" == '*' ]]; then
+      if [[ "${line:i+1:1}" == '*' ]]; then
+        # A '**' that forms a whole path segment spans directories.
+        local prev_ok=0 next_ok=0
+        { ((i == 0)) || [[ "${line:i-1:1}" == '/' ]]; } && prev_ok=1
+        { ((i + 2 == n)) || [[ "${line:i+2:1}" == '/' ]]; } && next_ok=1
+        if ((prev_ok && next_ok)); then
+          if ((i + 2 == n)); then
+            core+='.*' # trailing '**' matches everything below
+            i=$((i + 2))
+          else
+            core+='(.*/)?' # '**/' matches zero or more directories
+            i=$((i + 3))   # also consume the following '/'
+          fi
+          continue
+        fi
+      fi
+      core+='[^/]*' # single '*' does not cross directory separators
+      i=$((i + 1))
+      continue
+    fi
+    if [[ "$c" == '?' ]]; then
+      core+='[^/]'
+      i=$((i + 1))
+      continue
+    fi
+    if [[ "$c" == '[' ]]; then
+      # Copy a bracket expression through, translating a leading '!' to '^'.
+      local j=$((i + 1)) bracket='['
+      if [[ "${line:j:1}" == '!' || "${line:j:1}" == '^' ]]; then
+        bracket+='^'
+        j=$((j + 1))
+      fi
+      [[ "${line:j:1}" == ']' ]] && {
+        bracket+=']'
+        j=$((j + 1))
+      }
+      while ((j < n)) && [[ "${line:j:1}" != ']' ]]; do
+        bracket+="${line:j:1}"
+        j=$((j + 1))
+      done
+      if ((j < n)); then
+        core+="${bracket}]"
+        i=$((j + 1))
+      else
+        core+='\[' # no closing ']': treat '[' literally
+        i=$((i + 1))
+      fi
+      continue
+    fi
+    # Literal character: escape ERE metacharacters.
+    case "$c" in
+      '.' | '^' | '$' | '+' | '(' | ')' | '{' | '}' | '|' | '\') core+="\\$c" ;;
+      *) core+="$c" ;;
+    esac
+    i=$((i + 1))
+  done
+
+  local start end
+  if ((anchored)); then start='^'; else start='(^|.*/)'; fi
+  if ((dir_only)); then end='/'; else end='(/|$)'; fi
+
+  _LIBBIDSSH_BIDSIGNORE_REGEX+=("${start}${core}${end}")
+  _LIBBIDSSH_BIDSIGNORE_NEG+=("$negated")
+}
+
+_libBIDSsh_compile_bidsignore() {
+  # Compile the built-in default ignores plus a dataset's root .bidsignore into the
+  # module-level _LIBBIDSSH_BIDSIGNORE_REGEX / _LIBBIDSSH_BIDSIGNORE_NEG arrays, in
+  # match order. Safe to call repeatedly (arrays are reset each time). Only the
+  # root-level .bidsignore is read (no inheritance), matching bids-validator.
+  # Usage: _libBIDSsh_compile_bidsignore "<bidspath>" [use_defaults=1]
+  local bidspath="$1"
+  local use_defaults="${2:-1}"
+
+  _LIBBIDSSH_BIDSIGNORE_REGEX=()
+  _LIBBIDSSH_BIDSIGNORE_NEG=()
+
+  # Built-in defaults, mirroring bids-validator's addDefaults list. Note that
+  # derivatives/ is intentionally NOT ignored (libBIDS treats it as first-class).
+  if [[ "$use_defaults" == "1" ]]; then
+    local default_pattern
+    for default_pattern in '.git**' '.*' 'sourcedata/' 'code/' 'stimuli/' 'log/'; do
+      _libBIDSsh_compile_bidsignore_line "$default_pattern"
+    done
+  fi
+
+  local ignore_file="${bidspath%/}/.bidsignore"
+  if [[ -f "$ignore_file" ]]; then
+    local line
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      _libBIDSsh_compile_bidsignore_line "$line"
+    done <"$ignore_file"
+  fi
+}
+
+_libBIDSsh_path_is_ignored() {
+  # Test a dataset-root-relative path against the compiled .bidsignore patterns.
+  # Returns 0 if the path is ignored, 1 otherwise. Last matching pattern wins, so
+  # a later negation ('!') re-includes a path excluded by an earlier pattern.
+  # Usage: _libBIDSsh_path_is_ignored "<relative/path>"
+  local relpath="$1"
+  local is_ignored=0 idx regex
+  for ((idx = 0; idx < ${#_LIBBIDSSH_BIDSIGNORE_REGEX[@]}; idx++)); do
+    regex="${_LIBBIDSSH_BIDSIGNORE_REGEX[idx]}"
+    if [[ "$relpath" =~ $regex ]]; then
+      if [[ "${_LIBBIDSSH_BIDSIGNORE_NEG[idx]}" == "1" ]]; then
+        is_ignored=0
+      else
+        is_ignored=1
+      fi
+    fi
+  done
+  ((is_ignored)) && return 0
+  return 1
+}
+
+libBIDSsh_apply_bidsignore() {
+  # Drop rows whose file is excluded by a dataset's .bidsignore (and, by default,
+  # the built-in default ignores). Pipeline-style: TSV in -> filtered TSV out.
+  # Usage: libBIDSsh_apply_bidsignore "${table_data}" "<bidspath>" [--no-default-ignores]
+  # Example:
+  #   table=$(libBIDSsh_apply_bidsignore "$table" path/to/dataset)
+  local table_data="$1"
+  local bidspath="$2"
+  shift 2
+  local use_defaults=1
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --default-ignores) use_defaults=1; shift ;;
+      --no-default-ignores) use_defaults=0; shift ;;
+      *) echo "Unknown option: $1" >&2; return 1 ;;
+    esac
+  done
+
+  _libBIDSsh_compile_bidsignore "$bidspath" "$use_defaults"
+
+  local norm_bidspath
+  norm_bidspath=$(tr -s / <<<"${bidspath%/}")
+
+  local line lineno=0 path_idx=-1
+  while IFS= read -r line; do
+    lineno=$((lineno + 1))
+    if ((lineno == 1)); then
+      local -a hcols
+      IFS=$'\t' read -r -a hcols <<<"$line"
+      local hi
+      for hi in "${!hcols[@]}"; do
+        [[ "${hcols[hi]}" == "path" ]] && {
+          path_idx=$hi
+          break
+        }
+      done
+      if ((path_idx < 0)); then
+        echo "Error: no 'path' column in table data" >&2
+        return 1
+      fi
+      printf '%s\n' "$line"
+      continue
+    fi
+    local -a cols
+    IFS=$'\t' read -r -a cols <<<"$line"
+    local norm_p relpath
+    norm_p=$(tr -s / <<<"${cols[path_idx]}")
+    relpath="${norm_p#"${norm_bidspath}"/}"
+    if ! _libBIDSsh_path_is_ignored "$relpath"; then
+      printf '%s\n' "$line"
+    fi
+  done <<<"$table_data"
+}
+
 libBIDSsh_parse_bids_to_table() {
   # Parse a BIDS directory structure into TSV format
-  # Usage: libBIDSsh_parse_bids_to_table "/path/to/bids/dataset"
+  # Usage: libBIDSsh_parse_bids_to_table [OPTIONS] "/path/to/bids/dataset"
+  # Options:
+  #   --no-bidsignore        do not honor the dataset's .bidsignore or defaults
+  #   --no-default-ignores   honor .bidsignore but skip the built-in default ignores
   # Returns: TSV data through stdout with columns for each BIDS entity
   # Example:
   #   bids_table=$(libBIDSsh_parse_bids_to_table "/path/to/bids")
-  local bidspath="${1:-}"
+  local bidspath=""
+  local honor_bidsignore=1
+  local use_defaults=1
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --bidsignore) honor_bidsignore=1; shift ;;
+      --no-bidsignore) honor_bidsignore=0; shift ;;
+      --default-ignores) use_defaults=1; shift ;;
+      --no-default-ignores) use_defaults=0; shift ;;
+      -*) echo "Unknown option: $1" >&2; return 1 ;;
+      *)
+        if [[ -z "$bidspath" ]]; then
+          bidspath="$1"
+        else
+          echo "Error: unexpected extra argument '$1'" >&2
+          return 1
+        fi
+        shift
+        ;;
+    esac
+  done
   if [[ ! -d "$bidspath" ]]; then
     echo "Error: Directory '$bidspath' does not exist" >&2
     return 1
@@ -535,6 +802,30 @@ libBIDSsh_parse_bids_to_table() {
   shopt -u extglob
   shopt -u nullglob
   shopt -u globstar
+
+  # Drop files excluded by the dataset's .bidsignore (and built-in default
+  # ignores) unless disabled. Paths are matched relative to the dataset root.
+  if ((honor_bidsignore)); then
+    _libBIDSsh_compile_bidsignore "$bidspath" "$use_defaults"
+    if ((${#_LIBBIDSSH_BIDSIGNORE_REGEX[@]} > 0)); then
+      local norm_bidspath
+      norm_bidspath=$(tr -s / <<<"${bidspath%/}")
+      local -a kept_files=()
+      local f relpath
+      for f in "${files[@]}"; do
+        relpath=$(tr -s / <<<"$f")
+        relpath="${relpath#"${norm_bidspath}"/}"
+        if ! _libBIDSsh_path_is_ignored "$relpath"; then
+          kept_files+=("$f")
+        fi
+      done
+      if ((${#kept_files[@]})); then
+        files=("${kept_files[@]}")
+      else
+        files=()
+      fi
+    fi
+  fi
 
   # Order of entities from generate_entity_patterns.sh.
   # entities_order holds entity keys (filename tokens); entities_name_order holds
@@ -826,5 +1117,5 @@ if ! (return 0 2>/dev/null); then
     echo 'error: the first argument must be a path to a bids dataset'
     exit 1
   fi
-  libBIDSsh_parse_bids_to_table "${1}"
+  libBIDSsh_parse_bids_to_table "$@"
 fi

--- a/test_libBIDS.sh
+++ b/test_libBIDS.sh
@@ -236,6 +236,103 @@ test_json_to_associative_array() {
   return 0
 }
 
+# Build a small self-contained BIDS-shaped fixture with a .bidsignore.
+# Echoes the temp directory path; caller is responsible for removing it.
+_make_bidsignore_fixture() {
+  local root
+  root=$(mktemp -d)
+  local files=(
+    "sub-01/func/sub-01_task-rest_bold.nii.gz"
+    "sub-02/func/sub-02_task-rest_bold.nii.gz"
+    "sub-01/anat/sub-01_T1w.nii.gz"
+    "sub-01/anat/sub-01_FLASH.nii.gz"
+    "sourcedata/sub-01/anat/sub-01_T1w.nii.gz"
+    "code/sub-01_T1w.nii.gz"
+    "derivatives/junk/sub-01_desc-x_T1w.nii.gz"
+  )
+  local f
+  for f in "${files[@]}"; do
+    mkdir -p "${root}/$(dirname "$f")"
+    : >"${root}/${f}"
+  done
+  printf '%s\n' '*_FLASH.nii.gz' '*_bold.nii.gz' '!sub-01_task-rest_bold.nii.gz' \
+    >"${root}/.bidsignore"
+  printf '%s' "$root"
+}
+
+# Count data rows (all lines after the header).
+_row_count() { tail -n +2 <<<"$1" | grep -c .; }
+
+test_bidsignore_matcher() {
+  local root
+  root=$(mktemp -d)
+  printf '%s\n' '*_bold.nii.gz' '!sub-01_task-rest_bold.nii.gz' 'derivatives/junk/' \
+    'a/b/anchored.nii.gz' '**/deep_FLASH.nii.gz' >"${root}/.bidsignore"
+  _libBIDSsh_compile_bidsignore "$root" 1
+
+  local rc=0
+  _chk() { # path expected(0=ignored,1=kept) msg
+    if _libBIDSsh_path_is_ignored "$1"; then local got=0; else local got=1; fi
+    assert_equals "$2" "$got" "$3" || rc=1
+  }
+  _chk "sub-02/func/sub-02_task-rest_bold.nii.gz" 0 "basename glob ignores bold" # ignored
+  _chk "sub-01/func/sub-01_task-rest_bold.nii.gz" 1 "negation re-includes bold"  # kept
+  _chk "code/script.py" 0 "default ignore: code/"                                # ignored
+  _chk "sourcedata/x/y_bold.nii.gz" 0 "default ignore: sourcedata/"              # ignored
+  _chk "derivatives/junk/sub-01_T1w.nii.gz" 0 "directory pattern ignores subtree" # ignored
+  _chk "derivatives/keep/sub-01_T1w.nii.gz" 1 "derivatives not ignored by default" # kept
+  _chk "a/b/anchored.nii.gz" 0 "anchored path matches at root"                   # ignored
+  _chk "x/a/b/anchored.nii.gz" 1 "anchored path does not match at depth"         # kept
+  _chk "sub-01/anat/deep_FLASH.nii.gz" 0 "globstar matches across dirs"          # ignored
+  _chk ".git/config" 0 "default ignore: .git**"                                  # ignored
+
+  rm -rf "$root"
+  return $rc
+}
+
+test_bidsignore_parser() {
+  local root
+  root=$(_make_bidsignore_fixture)
+
+  local default raw nodefault
+  default=$(libBIDSsh_parse_bids_to_table "$root")
+  raw=$(libBIDSsh_parse_bids_to_table --no-bidsignore "$root")
+  nodefault=$(libBIDSsh_parse_bids_to_table --no-default-ignores "$root")
+
+  local rc=0
+  assert_equals "7" "$(_row_count "$raw")" "--no-bidsignore keeps all 7 files" || rc=1
+  assert_equals "3" "$(_row_count "$default")" "default drops FLASH/bold/sourcedata/code" || rc=1
+  assert_equals "5" "$(_row_count "$nodefault")" "--no-default-ignores keeps sourcedata+code" || rc=1
+
+  # FLASH always dropped when honoring; sourcedata dropped only by defaults.
+  [[ "$default" != *FLASH* ]] || { echo "    FLASH not dropped in default"; rc=1; }
+  [[ "$nodefault" != *FLASH* ]] || { echo "    FLASH not dropped in --no-default-ignores"; rc=1; }
+  [[ "$nodefault" == *sourcedata* ]] || { echo "    sourcedata missing in --no-default-ignores"; rc=1; }
+  [[ "$default" != *sourcedata* ]] || { echo "    sourcedata not dropped by defaults"; rc=1; }
+  # Negation keeps sub-01 rest bold but not sub-02.
+  [[ "$default" == *"sub-01_task-rest_bold"* ]] || { echo "    negated bold missing"; rc=1; }
+  [[ "$default" != *"sub-02_task-rest_bold"* ]] || { echo "    sub-02 bold not dropped"; rc=1; }
+
+  rm -rf "$root"
+  return $rc
+}
+
+test_apply_bidsignore() {
+  local root
+  root=$(_make_bidsignore_fixture)
+
+  local default raw applied
+  default=$(libBIDSsh_parse_bids_to_table "$root")
+  raw=$(libBIDSsh_parse_bids_to_table --no-bidsignore "$root")
+  applied=$(libBIDSsh_apply_bidsignore "$raw" "$root")
+
+  local rc=0
+  assert_equals "$default" "$applied" "apply_bidsignore matches parser default" || rc=1
+
+  rm -rf "$root"
+  return $rc
+}
+
 echo "Starting libBIDS.sh test suite..."
 echo "---"
 
@@ -248,6 +345,9 @@ run_test "Public API: libBIDSsh_extension_json_rows_to_column_json_path" test_ex
 run_test "Public API: libBIDSsh_table_column_to_array" test_table_column_to_array
 run_test "Public API: libBIDSsh_table_iterator" test_table_iterator
 run_test "Public API: libBIDSsh_json_to_associative_array" test_json_to_associative_array
+run_test "Internal: _libBIDSsh_path_is_ignored (.bidsignore matcher)" test_bidsignore_matcher
+run_test "Public API: libBIDSsh_parse_bids_to_table .bidsignore" test_bidsignore_parser
+run_test "Public API: libBIDSsh_apply_bidsignore" test_apply_bidsignore
 
 echo "---"
 echo "Test summary:"

--- a/test_libBIDS.sh
+++ b/test_libBIDS.sh
@@ -260,8 +260,8 @@ _make_bidsignore_fixture() {
   printf '%s' "$root"
 }
 
-# Count data rows (all lines after the header).
-_row_count() { tail -n +2 <<<"$1" | grep -c .; }
+# Count data rows (all non-empty lines after the header).
+_row_count() { awk 'NR > 1 && $0 != "" { c++ } END { print c + 0 }' <<<"$1"; }
 
 test_bidsignore_matcher() {
   local root


### PR DESCRIPTION
## Summary

Adds support for a dataset's root-level `.bidsignore` file (gitignore-style patterns) to `libBIDSsh_parse_bids_to_table`, aligning libBIDS.sh with `bids-validator` / pybids. Closes the long-standing gap tracked in [bids-specification#131](https://github.com/bids-standard/bids-specification/issues/131).

**Behavior (on by default):**
- Honors the root `.bidsignore` plus a built-in default-ignore list mirroring bids-validator's `addDefaults`: `.git**`, `.*`, `sourcedata/`, `code/`, `stimuli/`, `log/` — **not** `derivatives/`, which libBIDS treats as first-class.
- New flags: `--no-bidsignore` (ignore the feature entirely) and `--no-default-ignores` (honor `.bidsignore` but skip the built-in list).
- New public pipeline function `libBIDSsh_apply_bidsignore <table> <bidspath> [--no-default-ignores]` to filter an already-parsed table.

**Matcher** (pure bash, no new deps): full-ish gitignore semantics — `**` whole-segment globstar, `*`/`?` (non-`/`-crossing), `[...]` brackets, `\`-escapes, root anchoring via leading/embedded `/`, trailing-`/` directory-only patterns, and `!` negation with last-match-wins ordering.

## Integration point
The filter runs right after the file glob in the parser, trimming the `files` array before the TSV is emitted.

## Scope nuance
Because the parser only globs files whose suffix **and** extension are valid BIDS tokens, `.bidsignore` patterns targeting non-BIDS files (`*.html`, `*.csv`) are inherent no-ops. The feature bites for BIDS-shaped files an author explicitly excludes (e.g. `**/sub-*_..._FLASH.nii.gz`) and for the default-ignore directories.

## Limitations (documented)
- Root-level `.bidsignore` only (no inheritance / nested files), matching bids-validator.
- Negation does not specially block re-including a file under an already-excluded parent dir (each file's full relative path is tested independently).
- Escaped trailing whitespace (`\ `) is the one gitignore corner not fully honored.

## Testing
- 3 new unit tests (12 total, all passing): direct matcher rules, parser flags (default vs `--no-bidsignore` vs `--no-default-ignores`, incl. negation + defaults), and `apply_bidsignore` equivalence.
- Smoke-tested against `bids-examples/ds000117`: `**/sub-*_ses-mri_run-*_echo-*_FLASH.nii.gz` drops 238 FLASH rows → 0 by default, kept under `--no-bidsignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)